### PR TITLE
Fix ScriptAnalyzer process hanging on too much output

### DIFF
--- a/sonar-ps-plugin/src/main/java/org/sonar/plugins/powershell/sensors/ScriptAnalyzerSensor.java
+++ b/sonar-ps-plugin/src/main/java/org/sonar/plugins/powershell/sensors/ScriptAnalyzerSensor.java
@@ -70,7 +70,8 @@ public class ScriptAnalyzerSensor extends BaseSensor implements org.sonar.api.ba
 					outFile };
 
 			LOGGER.info(String.format("Starting Script-Analyzer using powershell: %s", Arrays.toString(args)));
-			final Process process = new ProcessBuilder(args).start();
+			final Process process = new ProcessBuilder(args).inheritIO().start();
+			super.read(process);
 			final int pReturnValue = process.waitFor();
 
 			if (pReturnValue != 0) {


### PR DESCRIPTION
Please consider this change to the ScriptAnalyzerSensor. This change makes sure the process is read in a loop so that the process does not hang when there is more output then the buffer on the running environment can handle.

Changed the ScriptAnalyzerSensor to call the read operation of the BaseSensor before waiting for the process to finish.

This fixes bug #9

The TokenizerSensor might need a similar fix, but it's process is less verbose and not causing a issue on my repositories.