### PR TITLE
Add missing rule PSUseSingularNouns

### DIFF
--- a/sonar-ps-plugin/src/main/resources/powershell-profile.xml
+++ b/sonar-ps-plugin/src/main/resources/powershell-profile.xml
@@ -180,6 +180,10 @@
             <repositoryKey>ps-psanalyzer</repositoryKey>
         </rule>
         <rule>
+            <key>PSUseSingularNouns</key>
+            <repositoryKey>ps-psanalyzer</repositoryKey>
+        </rule>
+        <rule>
             <key>PSUseSupportsShouldProcess</key>
             <repositoryKey>ps-psanalyzer</repositoryKey>
         </rule>

--- a/sonar-ps-plugin/src/main/resources/powershell-rules.xml
+++ b/sonar-ps-plugin/src/main/resources/powershell-rules.xml
@@ -529,6 +529,18 @@
         <severity>MAJOR</severity>
     </rule>
     <rule>
+        <key>PSUseSingularNouns</key>
+        <internalKey>PSUseSingularNouns</internalKey>
+        <name>Cmdlet Singular Noun</name>
+        <description>Cmdlet should use singular instead of plural nouns.</description>
+        <cardinality>SINGLE</cardinality>
+        <remediationFunction>LINEAR</remediationFunction>
+        <descriptionFormat>MARKDOWN</descriptionFormat>
+        <remediationFunctionBaseEffort />
+        <debtRemediationFunctionCoefficient>5min</debtRemediationFunctionCoefficient>
+        <severity>MAJOR</severity>
+    </rule>
+    <rule>
         <key>PSUseSupportsShouldProcess</key>
         <internalKey>PSUseSupportsShouldProcess</internalKey>
         <name>Use SupportsShouldProcess</name>


### PR DESCRIPTION
Running "regenerateRulesDefinition.ps1" adds this rule to the "powershell-rules.xml" and "powershell-profile.xml" on my environment. This rule seems to be missing in 0.3.2.

Fixes #11 

