### PR TITLE
bring back the quotes around the analysisfile

### DIFF
--- a/sonar-ps-plugin/src/main/java/org/sonar/plugins/powershell/sensors/TokenizerSensor.java
+++ b/sonar-ps-plugin/src/main/java/org/sonar/plugins/powershell/sensors/TokenizerSensor.java
@@ -86,7 +86,7 @@ public class TokenizerSensor extends BaseSensor implements org.sonar.api.batch.s
 		for (final InputFile inputFile : inputFiles) {
 			try {
 
-				final String analysisFile = inputFile.file().getAbsolutePath();
+				final String analysisFile = String.format("'%s'", inputFile.file().getAbsolutePath());
 
 				// skip reporting temp files
 				if (analysisFile.contains(".scannerwork")) {


### PR DESCRIPTION
This pull request brings back the quoting around the analysisfile that was present in the previous version and is required for paths with spaces on Windows.

fixes #13 