### PR TITLE
Improve support for SonarQube 10

### DIFF
--- a/sonar-ps-plugin/pom.xml
+++ b/sonar-ps-plugin/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>org.sonar.plugins</groupId>
 	<artifactId>sonar-ps-plugin</artifactId>
 	<packaging>sonar-plugin</packaging>
-	<version>0.5.3</version>
+	<version>0.5.4</version>
 
 	<name>Powershell Plugin for SonarQube</name>
 	<description>Powershell plugin for SonarQube</description>
@@ -95,10 +95,11 @@
 			<plugin>
 				<groupId>org.sonarsource.sonar-packaging-maven-plugin</groupId>
 				<artifactId>sonar-packaging-maven-plugin</artifactId>
-				<version>1.16</version>
+				<version>1.23.0.740</version>
 				<extensions>true</extensions>
 				<configuration>
 					<pluginClass>org.sonar.plugins.powershell.PowershellPlugin</pluginClass>
+					<requiredForLanguages>ps</requiredForLanguages>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/sonar-ps-plugin/src/main/java/org/sonar/plugins/powershell/PowershellPlugin.java
+++ b/sonar-ps-plugin/src/main/java/org/sonar/plugins/powershell/PowershellPlugin.java
@@ -24,7 +24,7 @@ public class PowershellPlugin implements Plugin {
                 .type(PropertyType.INTEGER).build());
         context.addExtension(PropertyDefinition.builder(Constants.FILE_SUFFIXES).name("Suffixes to analyze")
                 .description("Suffixes supported by the plugin").defaultValue(".ps1,.psm1,.psd1")
-                .type(PropertyType.STRING).build());
+                .multiValues(true).type(PropertyType.STRING).build());
 
         context.addExtension(PropertyDefinition.builder(Constants.EXTERNAL_RULES_SKIP_LIST)
                 .name("External rules reporting skip list").description("List of repoId:ruleId pairs to skip reporting")


### PR DESCRIPTION
This resolves the warning that is emitted when analysing using the latest SonarQube 10.6 release:

```
WARN: Property 'sonar.ps.file.suffixes' is not declared as multi-values/property set but was read using 'getStringArray' method. The SonarQube plugin declaring this property should be updated.
```


In addition this also [configures the plugin for analyzer loading optimization](https://docs.sonarsource.com/sonarqube/latest/extension-guide/developing-a-plugin/plugin-basics/#configuring-plugins-for-analyzer-loading-optimization) under SonarQube 10.